### PR TITLE
Make publishing simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Love them or hate them, the [ODBC](https://en.wikipedia.org/wiki/Open_Database_Connectivity) and [JDBC](https://en.wikipedia.org/wiki/Java_Database_Connectivity) standards have made it easy to use a wide range of desktop and server products with many different databases thanks to the availability of database drivers implementing these standards.
 
-This project provides a Rust equivalent API as well as reference implementations (drivers) for Postgres, MySQL, and SQLite. 
+This project provides a Rust equivalent API as well as reference implementations (drivers) for Postgres, MySQL, and SQLite. There is also an RDBC-ODBC driver being developed, that will allow ODBC drivers to be called via the RDBC API, so that it is also possible to connect to databases that do not yet have Rust drivers available.
 
 Note that the provided RDBC drivers are just wrappers around existing database driver crates and this project is not attempting to build new drivers from scratch but rather make it possible to leverage existing drivers through a common API.
 

--- a/rdbc-cli/Cargo.toml
+++ b/rdbc-cli/Cargo.toml
@@ -7,13 +7,9 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-rdbc = { path = "../rdbc" }
-rdbc-mysql = { path = "../rdbc-mysql" }
-rdbc-postgres = { path = "../rdbc-postgres" }
-
-#rdbc = "0.1.4"
-#rdbc-mysql = "0.1.4"
-#rdbc-postgres = "0.1.4"
+rdbc = { path = "../rdbc", version = "0.1.4" }
+rdbc-mysql = { path = "../rdbc-mysql", version = "0.1.4" }
+rdbc-postgres = { path = "../rdbc-postgres", version = "0.1.4" }
 
 clap = "2.33.0"
 rustyline = "4.1.0"

--- a/rdbc-mysql/Cargo.toml
+++ b/rdbc-mysql/Cargo.toml
@@ -8,8 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-rdbc = { path = "../rdbc" }
-#rdbc = "0.1.4"
+rdbc = { path = "../rdbc", version = "0.1.4" }
 
 mysql = "17.0.0"
 mysql_common = "0.19.2"

--- a/rdbc-odbc/Cargo.toml
+++ b/rdbc-odbc/Cargo.toml
@@ -3,11 +3,10 @@ name = "rdbc-odbc"
 description = "RDBC-ODBC Bridge"
 authors = ["Andy Grove <andygrove73@gmail.com>"]
 license = "Apache-2.0"
-version = "0.1.2"
+version = "0.1.4"
 edition = "2018"
 
 [dependencies]
-rdbc = { path = "../rdbc" }
-#rdbc = "0.1.2"
+rdbc = { path = "../rdbc", version = "0.1.4" }
 
 odbc = "0.16.1"

--- a/rdbc-odbc/src/lib.rs
+++ b/rdbc-odbc/src/lib.rs
@@ -6,7 +6,7 @@ use odbc::odbc_safe::{AutocommitMode, Version, Odbc3};
 use odbc::{Environment, HasResult, Allocated, NoResult, Prepared};
 
 use rdbc;
-use rdbc::{Error, ResultSet, Statement, Value};
+use rdbc::{Error, ResultSet, Statement, Value, ResultSetMetaData};
 use odbc::ResultSetState::{NoData, Data};
 
 struct OdbcDriver {
@@ -35,6 +35,11 @@ struct OdbcConnection<'a, V> where V: AutocommitMode {
 }
 
 impl<'a, V> rdbc::Connection for OdbcConnection<'a, V> where V: AutocommitMode {
+
+    fn create(&mut self, sql: &str) -> rdbc::Result<Rc<RefCell<dyn rdbc::Statement + '_>>> {
+        self.prepare(sql)
+    }
+
     fn prepare(&mut self, sql: &str) -> rdbc::Result<Rc<RefCell<dyn rdbc::Statement + '_>>> {
         let stmt = odbc::Statement::with_parent(&self.conn).unwrap();
         let stmt = stmt.prepare(&sql).unwrap();
@@ -50,22 +55,24 @@ impl<'con, 'b, AC> rdbc::Statement for OdbcStatement<'con, 'b, AC> where AC: Aut
 
     fn execute_query(
         &mut self,
-        params: &Vec<Value>,
+        params: &[Value],
     ) -> rdbc::Result<Rc<RefCell<dyn rdbc::ResultSet + '_>>> {
 
         //TODO bind params
         //self.stmt.bind_parameter(0, "foo");
 
-        match self.stmt.execute().unwrap() {
-            Data(mut stmt) => {
-                //Ok(Rc::new(RefCell::new(OdbcStatement { stmt, sql: sql.to_owned() })) as Rc<RefCell<dyn rdbc::Statement>>)
-                unimplemented!()
-            },
-            NoData(_) => unimplemented!()
-        }
+//        match self.stmt.execute().unwrap() {
+//            Data(mut stmt) => {
+//                //Ok(Rc::new(RefCell::new(OdbcStatement { stmt, sql: sql.to_owned() })) as Rc<RefCell<dyn rdbc::Statement>>)
+//                unimplemented!()
+//            },
+//            NoData(_) => unimplemented!()
+//        }
+
+        unimplemented!()
     }
 
-    fn execute_update(&mut self, params: &Vec<Value>) -> rdbc::Result<u64> {
+    fn execute_update(&mut self, params: &[Value]) -> rdbc::Result<u64> {
         unimplemented!()
     }
 }
@@ -73,15 +80,20 @@ impl<'con, 'b, AC> rdbc::Statement for OdbcStatement<'con, 'b, AC> where AC: Aut
 struct OdbcResultSet {}
 
 impl rdbc::ResultSet for OdbcResultSet {
+
+    fn meta_data(&self) -> Result<Rc<ResultSetMetaData>, Error> {
+        unimplemented!()
+    }
+
     fn next(&mut self) -> bool {
         unimplemented!()
     }
 
-    fn get_i32(&self, i: usize) -> Option<i32> {
+    fn get_i32(&self, i: u64) -> Option<i32> {
         unimplemented!()
     }
 
-    fn get_string(&self, i: usize) -> Option<String> {
+    fn get_string(&self, i: u64) -> Option<String> {
         unimplemented!()
     }
 }
@@ -107,11 +119,3 @@ impl rdbc::ResultSet for OdbcResultSet {
 //
 //    Ok(())
 //}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/rdbc-postgres/Cargo.toml
+++ b/rdbc-postgres/Cargo.toml
@@ -8,8 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-rdbc = { path = "../rdbc" }
-#rdbc = "0.1.4"
+rdbc = { path = "../rdbc", version = "0.1.4" }
 
 postgres = "0.15.2"
 sqlparser = "0.5.0"

--- a/rdbc-sqlite/Cargo.toml
+++ b/rdbc-sqlite/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "rdbc-sqlite"
 description = "SQLite RDBC Driver"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Andy Grove <andygrove73@gmail.com>", "Manuel Woelker <github@manuel.woelker.org>"]
 license = "Apache-2.0"
 
 edition = "2018"
 
 [dependencies]
-rdbc = { path = "../rdbc" }
-#rdbc = "0.1.4"
+rdbc = { path = "../rdbc", version = "0.1.4" }
 
 rusqlite = { version = "0.21.0", features = ["bundled"]}
 fallible-streaming-iterator = "0.1"


### PR DESCRIPTION
Provide both `path` and `version` for internal dependencies.