### PR TITLE
Add Row trait [WIP]

### DIFF
--- a/rdbc-cli/src/main.rs
+++ b/rdbc-cli/src/main.rs
@@ -86,7 +86,7 @@ fn execute(conn: &mut dyn Connection, sql: &str) -> Result<()> {
     }
     println!();
 
-    while let Ok(Some(row)) = rs.next() {
+    while let Some(row) = rs.next()? {
         for i in 0..meta.num_columns() {
             if i > 0 {
                 print!("\t");

--- a/rdbc-cli/src/main.rs
+++ b/rdbc-cli/src/main.rs
@@ -86,16 +86,16 @@ fn execute(conn: &mut dyn Connection, sql: &str) -> Result<()> {
     }
     println!();
 
-    while rs.next() {
+    while let Ok(Some(row)) = rs.next() {
         for i in 0..meta.num_columns() {
             if i > 0 {
                 print!("\t");
             }
             match meta.column_type(i) {
-                DataType::Utf8 => print!("{:?}", rs.get_string(i)),
-                DataType::Integer => print!("{:?}", rs.get_i32(i)),
+                DataType::Utf8 => print!("{:?}", row.get_string(i)),
+                DataType::Integer => print!("{:?}", row.get_i32(i)),
                 // TODO other types
-                _ => print!("{:?}", rs.get_string(i)),
+                _ => print!("{:?}", row.get_string(i)),
             }
         }
         println!();

--- a/rdbc-mysql/src/lib.rs
+++ b/rdbc-mysql/src/lib.rs
@@ -150,10 +150,9 @@ impl<'a> rdbc::ResultSet for MySQLResultSet<'a> {
 
     fn next(&mut self) -> rdbc::Result<Option<Box<dyn rdbc::Row>>> {
         todo!()
-//        self.row = self.result.next();
-//        self.row.is_some()
+        //        self.row = self.result.next();
+        //        self.row.is_some()
     }
-
 }
 
 struct MySQLRow {
@@ -171,7 +170,6 @@ impl rdbc::Row for MySQLRow {
         get_string -> String,
         get_bytes -> Vec<u8>
     }
-
 }
 
 fn to_rdbc_type(t: &ColumnType) -> rdbc::DataType {

--- a/rdbc-postgres/src/lib.rs
+++ b/rdbc-postgres/src/lib.rs
@@ -137,10 +137,10 @@ impl rdbc::ResultSet for PResultSet {
     fn next(&mut self) -> rdbc::Result<Option<Box<dyn rdbc::Row>>> {
         if self.i < self.rows.len() {
             self.i = self.i + 1;
-            //TODO fix lifetime issue here
-            //            let row = &self.rows.get(self.i - 1);
-            //            Ok(Some(Box::new(PRow { row: &row })))
-            todo!()
+            let p_row = &self.rows.get(self.i - 1);
+            let row: Vec<rdbc::Value> = vec![];
+            //TODO copy data from postgres row into vec
+            Ok(Some(Box::new(row)))
         } else {
             Ok(None)
         }

--- a/rdbc-postgres/src/lib.rs
+++ b/rdbc-postgres/src/lib.rs
@@ -17,7 +17,7 @@
 //! }
 //! ```
 
-use postgres::rows::{Rows, Row};
+use postgres::rows::{Row, Rows};
 use postgres::{Connection, TlsMode};
 
 use sqlparser::dialect::PostgreSqlDialect;
@@ -129,7 +129,6 @@ struct PResultSet {
     rows: Rows,
 }
 
-
 impl rdbc::ResultSet for PResultSet {
     fn meta_data(&self) -> rdbc::Result<Box<dyn rdbc::ResultSetMetaData>> {
         Ok(Box::new(self.meta.clone()))
@@ -139,15 +138,14 @@ impl rdbc::ResultSet for PResultSet {
         if self.i < self.rows.len() {
             self.i = self.i + 1;
             //TODO fix lifetime issue here
-//            let row = &self.rows.get(self.i - 1);
-//            Ok(Some(Box::new(PRow { row: &row })))
+            //            let row = &self.rows.get(self.i - 1);
+            //            Ok(Some(Box::new(PRow { row: &row })))
             todo!()
         } else {
             Ok(None)
         }
     }
 }
-
 
 macro_rules! impl_resultset_fns {
     ($($fn: ident -> $ty: ty),*) => {

--- a/rdbc-sqlite/src/lib.rs
+++ b/rdbc-sqlite/src/lib.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use fallible_streaming_iterator::FallibleStreamingIterator;
-use rusqlite::{Rows, Row};
+use rusqlite::{Row, Rows};
 
 /// Convert a Sqlite error into an RDBC error
 fn to_rdbc_err(e: rusqlite::Error) -> rdbc::Error {
@@ -102,12 +102,12 @@ impl<'stmt> rdbc::ResultSet for SResultSet<'stmt> {
         Ok(Box::new(meta))
     }
 
-    fn next(&mut self) -> rdbc::Result<Option<Box<dyn rdbc::Row>>>  {
+    fn next(&mut self) -> rdbc::Result<Option<Box<dyn rdbc::Row>>> {
         //TODO implement
         match self.rows.next() {
             Ok(Some(row)) => todo!(),
             Ok(None) => Ok(None),
-            _ => todo!()
+            _ => todo!(),
         }
     }
 }
@@ -125,11 +125,10 @@ macro_rules! impl_row_fns {
 }
 
 struct SRow<'stmt> {
-    row: Row<'stmt>
+    row: Row<'stmt>,
 }
 
-impl<'stmt> rdbc::Row for SRow<'stmt>  {
-
+impl<'stmt> rdbc::Row for SRow<'stmt> {
     fn get_f32(&self, _i: u64) -> rdbc::Result<Option<f32>> {
         Err(rdbc::Error::General("f32 not supported".to_owned()))
     }

--- a/rdbc-sqlite/src/lib.rs
+++ b/rdbc-sqlite/src/lib.rs
@@ -104,10 +104,14 @@ impl<'stmt> rdbc::ResultSet for SResultSet<'stmt> {
 
     fn next(&mut self) -> rdbc::Result<Option<Box<dyn rdbc::Row>>> {
         //TODO implement
-        match self.rows.next() {
-            Ok(Some(row)) => todo!(),
-            Ok(None) => Ok(None),
-            _ => todo!(),
+        match self.rows.next()
+            .map_err(|e| to_rdbc_err(e))? {
+            Some(row) => {
+                let row: Vec<rdbc::Value> = vec![];
+                //TODO copy data from sqlite row into vec
+                Ok(Some(Box::new(row)))
+            },
+            None => Ok(None)
         }
     }
 }

--- a/rdbc/src/lib.rs
+++ b/rdbc/src/lib.rs
@@ -119,6 +119,41 @@ pub enum DataType {
     Binary,
 }
 
+impl Row for Vec<Value> {
+
+    fn get_i8(&self, i: u64) -> Result<Option<i8>> {
+        unimplemented!()
+    }
+
+    fn get_i16(&self, i: u64) -> Result<Option<i16>> {
+        unimplemented!()
+    }
+
+    fn get_i32(&self, i: u64) -> Result<Option<i32>> {
+        unimplemented!()
+    }
+
+    fn get_i64(&self, i: u64) -> Result<Option<i64>> {
+        unimplemented!()
+    }
+
+    fn get_f32(&self, i: u64) -> Result<Option<f32>> {
+        unimplemented!()
+    }
+
+    fn get_f64(&self, i: u64) -> Result<Option<f64>> {
+        unimplemented!()
+    }
+
+    fn get_string(&self, i: u64) -> Result<Option<String>> {
+        unimplemented!()
+    }
+
+    fn get_bytes(&self, i: u64) -> Result<Option<Vec<u8>>> {
+        unimplemented!()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Column {
     name: String,

--- a/rdbc/src/lib.rs
+++ b/rdbc/src/lib.rs
@@ -77,9 +77,12 @@ pub trait ResultSet {
     /// get meta data about this result set
     fn meta_data(&self) -> Result<Box<dyn ResultSetMetaData>>;
 
-    /// Move the cursor to the next available row if one exists and return true if it does
-    fn next(&mut self) -> bool;
+    /// Fetch the next row
+    fn next(&mut self) -> Result<Option<Box<dyn Row>>>;
+}
 
+/// Row
+pub trait Row {
     fn get_i8(&self, i: u64) -> Result<Option<i8>>;
     fn get_i16(&self, i: u64) -> Result<Option<i16>>;
     fn get_i32(&self, i: u64) -> Result<Option<i32>>;
@@ -88,6 +91,7 @@ pub trait ResultSet {
     fn get_f64(&self, i: u64) -> Result<Option<f64>>;
     fn get_string(&self, i: u64) -> Result<Option<String>>;
     fn get_bytes(&self, i: u64) -> Result<Option<Vec<u8>>>;
+    //TODO add accessors for date, time, timestamp and other ANSI SQL types
 }
 
 /// Meta data for result set


### PR DESCRIPTION
As a first step towards moving to async and returning `impl Stream<Row>` this PR aims to introduce a `Row` trait and change the `ResultSet.next()` method to return an `Option<Row>`.

```rust

/// Result set from executing a query against a statement
pub trait ResultSet {
    /// get meta data about this result set
    fn meta_data(&self) -> Result<Box<dyn ResultSetMetaData>>;

    /// Fetch the next row
    fn next(&mut self) -> Result<Option<Box<dyn Row>>>;
}

/// Row
pub trait Row {
    fn get_i8(&self, i: u64) -> Result<Option<i8>>;
    fn get_i16(&self, i: u64) -> Result<Option<i16>>;
    fn get_i32(&self, i: u64) -> Result<Option<i32>>;
    fn get_i64(&self, i: u64) -> Result<Option<i64>>;
    fn get_f32(&self, i: u64) -> Result<Option<f32>>;
    fn get_f64(&self, i: u64) -> Result<Option<f64>>;
    fn get_string(&self, i: u64) -> Result<Option<String>>;
    fn get_bytes(&self, i: u64) -> Result<Option<Vec<u8>>>;
    //TODO add accessors for date, time, timestamp and other ANSI SQL types
}
```

One concern that I have with this approach is that now each `Row` is boxed so that seems inefficient?

Also, I'm struggling to implement it for Postgres and SQLite due to lifetime issues.
